### PR TITLE
Updated pom.xml to exclude native jar files during unit tests and better method for excluding in maven-shade-plugin for server jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,12 +157,12 @@
     <dependency>
         <groupId>com.senzing</groupId>
         <artifactId>sz-sdk-auto</artifactId>
-        <version>0.3.0</version>
+        <version>0.4.1</version>
     </dependency>
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-commons</artifactId>
-      <version>4.0.0-beta.1.3</version>
+      <version>4.0.0-beta.1.4</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>


### PR DESCRIPTION
Also updated pom.xml version to 0.2.0 for changes including upgrade to v4.33.0 for `com.google.protobuf` artifacts.