### PR TITLE
Changes to publish the server jar to maven central.

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -178,17 +178,19 @@ The system property `com.linecorp.armeria.transportType=nio` must be set in a **
 
 ### Exception Handling Convention
 
-Server-side exception handling in `SzGrpcServer`:
+Server-side exception handling in `SzGrpcServices`:
 
 - Map Java exception types to gRPC `Status` codes via `STATUS_MAP`
 - For `SzException`, preserve error code in reason string as `SENZ<code>|<message>`
 - Include stack trace and function information in JSON structure
+- See `SzGrpcServices.inferStatus()` and `SzGrpcServices.toStatusRuntimeException()`
 
 Client-side parsing in `SzGrpcEnvironment`:
 
 - Extract error code from reason prefix
 - Parse JSON error structure for additional context
 - Reconstruct appropriate `SzException` subclass using `SzCoreUtilities.createSzException()`
+- See `SzGrpcEnvironment.createSzException()`
 
 ### Checkstyle Suppressions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], [markdownlint],
 and this project adheres to [Semantic Versioning].
 
+## [0.7.1] - 2026-03-05
+
+### Changes/Additions/Fixes in version 0.7.1
+
+- Fixed server JAR not being published to Maven Central by attaching it as a
+  classified artifact (`server` classifier).
+
 ## [0.7.0] - 2026-03-02
 
 ### Changes/Additions/Fixes in version 0.7.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,10 @@ RUN apt-get update \
 # Stage: builder
 # -----------------------------------------------------------------------------
 FROM ${IMAGE_BUILDER} AS builder
-ENV REFRESHED_AT=2026-03-02
+ENV REFRESHED_AT=2026-03-05
 LABEL Name="senzing/java-builder" \
        Maintainer="support@senzing.com" \
-       Version="0.7.0"
+       Version="0.7.1"
 
 # Run as "root" for system installation.
 
@@ -90,10 +90,10 @@ RUN mvn -ntp -DskipTests=true package
 # -----------------------------------------------------------------------------
 
 FROM ${IMAGE_FINAL} AS final
-ENV REFRESHED_AT=2026-03-02
+ENV REFRESHED_AT=2026-03-05
 LABEL Name="senzing/sz-sdk-grpc-java" \
        Maintainer="support@senzing.com" \
-       Version="0.7.0"
+       Version="0.7.1"
 #HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD ["/app/healthcheck.sh"]
 HEALTHCHECK CMD ["echo hello"]
 USER root

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>sz-sdk-grpc</artifactId>
   <packaging>jar</packaging>
-  <version>0.7.0</version>
+  <version>0.7.1</version>
   <name>Senzing Java GRPC SDK</name>
   <description>The Java GRPC Client SDK for Senzing.  This requires a compatible GRPC server at runtime.</description>
   <url>http://github.com/senzing-garage/sz-sdk-java-grpc</url>
@@ -336,7 +336,23 @@
               <sources>
                 <source>${project.build.directory}/generated-sources/senzing</source>
               </sources>
-            </configuration>  
+            </configuration>
+          </execution>
+          <execution>
+            <id>attach-server-jar</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <configuration>
+              <artifacts>
+                <artifact>
+                  <file>${project.build.directory}/${project.artifactId}-server.jar</file>
+                  <type>jar</type>
+                  <classifier>server</classifier>
+                </artifact>
+              </artifacts>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Attach the server JAR as a classified artifact using build-helper-maven-plugin so it is published alongside the client JAR. Downstream projects reference it with classifier "server".

Update CLAUDE.md exception handling references from SzGrpcServer to SzGrpcServices. Bump version to 0.7.1.
