### PR TITLE
Version 0.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning].
 - Updated `io.netty/netty-bom` from 4.2.10.Final to 4.2.12.Final.
 - Updated `com.senzing/data-mart-replicator` from 2.0.0-beta.2.2 to 2.0.0-beta.2.4.
 - Updated `com.ibm.icu/icu4j` from 78.2 to 78.3.
+- Updated `com.senzing/sz-sdk` minimum version from 4.1.0 to 4.3.0.
 - Updated `com.github.spotbugs/spotbugs-maven-plugin` from 4.9.8.2 to 4.9.8.3.
 
 ## [0.7.2] - 2026-03-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], [markdownlint],
 and this project adheres to [Semantic Versioning].
 
-## [0.7.3] - 2026-04-07
+## [0.8.0] - 2026-04-07
 
-### Changes/Additions/Fixes in version 0.7.3
+### Changes/Additions/Fixes in version 0.8.0
 
 - Updated `io.grpc/grpc-bom` from 1.79.0 to 1.80.0.
 - Updated `com.google.protobuf/protobuf-java-util` from 4.33.6 to 4.34.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], [markdownlint],
 and this project adheres to [Semantic Versioning].
 
+## [0.7.3] - 2026-04-07
+
+### Changes/Additions/Fixes in version 0.7.3
+
+- Updated `io.grpc/grpc-bom` from 1.79.0 to 1.80.0.
+- Updated `com.google.protobuf/protobuf-java-util` from 4.33.6 to 4.34.1.
+- Updated `com.google.protobuf/protoc` from 4.33.2 to 4.34.1.
+- Updated `io.netty/netty-bom` from 4.2.10.Final to 4.2.12.Final.
+- Updated `com.senzing/data-mart-replicator` from 2.0.0-beta.2.2 to 2.0.0-beta.2.4.
+- Updated `com.ibm.icu/icu4j` from 78.2 to 78.3.
+- Updated `com.github.spotbugs/spotbugs-maven-plugin` from 4.9.8.2 to 4.9.8.3.
+
 ## [0.7.2] - 2026-03-24
 
 ### Changes/Additions/Fixes in version 0.7.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ FROM ${IMAGE_BUILDER} AS builder
 ENV REFRESHED_AT=2026-04-07
 LABEL Name="senzing/java-builder" \
        Maintainer="support@senzing.com" \
-       Version="0.7.3"
+       Version="0.8.0"
 
 # Run as "root" for system installation.
 
@@ -93,7 +93,7 @@ FROM ${IMAGE_FINAL} AS final
 ENV REFRESHED_AT=2026-04-07
 LABEL Name="senzing/sz-sdk-grpc-java" \
        Maintainer="support@senzing.com" \
-       Version="0.7.3"
+       Version="0.8.0"
 #HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD ["/app/healthcheck.sh"]
 HEALTHCHECK CMD ["echo hello"]
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,10 @@ RUN apt-get update \
 # Stage: builder
 # -----------------------------------------------------------------------------
 FROM ${IMAGE_BUILDER} AS builder
-ENV REFRESHED_AT=2026-03-24
+ENV REFRESHED_AT=2026-04-07
 LABEL Name="senzing/java-builder" \
        Maintainer="support@senzing.com" \
-       Version="0.7.2"
+       Version="0.7.3"
 
 # Run as "root" for system installation.
 
@@ -90,10 +90,10 @@ RUN mvn -ntp -DskipTests=true package
 # -----------------------------------------------------------------------------
 
 FROM ${IMAGE_FINAL} AS final
-ENV REFRESHED_AT=2026-03-24
+ENV REFRESHED_AT=2026-04-07
 LABEL Name="senzing/sz-sdk-grpc-java" \
        Maintainer="support@senzing.com" \
-       Version="0.7.2"
+       Version="0.7.3"
 #HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD ["/app/healthcheck.sh"]
 HEALTHCHECK CMD ["echo hello"]
 USER root

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>sz-sdk-grpc</artifactId>
   <packaging>jar</packaging>
-  <version>0.7.3</version>
+  <version>0.8.0</version>
   <name>Senzing Java GRPC SDK</name>
   <description>The Java GRPC Client SDK for Senzing.  This requires a compatible GRPC server at runtime.</description>
   <url>http://github.com/senzing-garage/sz-sdk-java-grpc</url>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>sz-sdk-grpc</artifactId>
   <packaging>jar</packaging>
-  <version>0.7.2</version>
+  <version>0.7.3</version>
   <name>Senzing Java GRPC SDK</name>
   <description>The Java GRPC Client SDK for Senzing.  This requires a compatible GRPC server at runtime.</description>
   <url>http://github.com/senzing-garage/sz-sdk-java-grpc</url>
@@ -40,9 +40,9 @@
   <properties>
     <gpg.skip>true</gpg.skip> <!-- skip GPG unless release profile -->
     <maven.compiler.release>17</maven.compiler.release>
-    <grpc.version>1.79.0</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>4.33.6</protobuf.version>
-    <protoc.version>4.33.2</protoc.version>
+    <grpc.version>1.80.0</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <protobuf.version>4.34.1</protobuf.version>
+    <protoc.version>4.34.1</protoc.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
@@ -66,7 +66,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
-        <version>4.2.10.Final</version>
+        <version>4.2.12.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -165,7 +165,7 @@
     <dependency>
         <groupId>com.senzing</groupId>
         <artifactId>sz-sdk</artifactId>
-        <version>[4.1.0,4.9999999.9999999]</version>
+        <version>[4.3.0,4.9999999.9999999]</version>
     </dependency>
     <dependency>
         <groupId>com.senzing</groupId>
@@ -175,7 +175,7 @@
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>data-mart-replicator</artifactId>
-      <version>2.0.0-beta.2.2</version>
+      <version>2.0.0-beta.2.4</version>
     </dependency>
     <dependency>
       <groupId>com.senzing</groupId>
@@ -201,7 +201,7 @@
     <dependency>
       <groupId>com.ibm.icu</groupId>
       <artifactId>icu4j</artifactId>
-      <version>78.2</version>
+      <version>78.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -816,7 +816,7 @@ public final class Sz$1Grpc {]]></value>
           <plugin>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-maven-plugin</artifactId>
-            <version>4.9.8.2</version>
+            <version>4.9.8.3</version>
             <configuration>
               <plugins>
                 <plugin>


### PR DESCRIPTION
- Bumped project version from 0.7.2 to 0.8.0
- Updated io.grpc/grpc-bom from 1.79.0 to 1.80.0
- Updated com.google.protobuf/protobuf-java-util from 4.33.6 to 4.34.1
- Updated com.google.protobuf/protoc from 4.33.2 to 4.34.1
- Updated io.netty/netty-bom from 4.2.10.Final to 4.2.12.Final
- Updated com.senzing/data-mart-replicator from 2.0.0-beta.2.2 to 2.0.0-beta.2.4
- Updated com.ibm.icu/icu4j from 78.2 to 78.3
- Updated com.github.spotbugs/spotbugs-maven-plugin from 4.9.8.2 to 4.9.8.3
- Updated Dockerfile REFRESHED_AT and Version labels for 0.7.3
- Updated CHANGELOG.md with 0.7.3 entry
