### PR TITLE
Prepare 1.0.1 release

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,15 +2,24 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## **IMPORTANT: Code Change Policy**
+## **IMPORTANT: Git Workflow Policy**
 
-**DO NOT make direct code changes.** Instead, analyze the code, identify issues, and provide suggestions for changes. The user will review and make the changes themselves. This applies to:
+**Never force-push.** Use only regular `git push`. Force-push (including
+`--force` and `--force-with-lease`) rewrites remote history and is
+prohibited in this repository's workflow.
 
-- Source code modifications
-- Configuration file changes
-- Documentation updates (except CLAUDE.md itself when explicitly requested)
+To avoid the need for a force-push, always base feature branches off
+the **latest `origin/main`**:
 
-Always present recommendations clearly with explanations and let the user decide how to proceed.
+1. `git fetch origin`
+2. `git checkout main && git pull --ff-only origin main`
+3. `git checkout -b <feature-branch>`
+4. Make commits, then `git push`, then create the PR.
+
+If `origin/main` has moved forward while you were working, **merge**
+`origin/main` into the feature branch (or rebase locally before the
+first push) — do **not** amend or rebase commits that have already
+been pushed.
 
 ### Editing CLAUDE.md
 

--- a/.github/workflows/create-javadoc-documentation.yaml
+++ b/.github/workflows/create-javadoc-documentation.yaml
@@ -32,7 +32,7 @@ jobs:
           submodules: recursive
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v5.2.0
         with:
           java-version: "21"
           distribution: "temurin"

--- a/.github/workflows/maven-darwin.yaml
+++ b/.github/workflows/maven-darwin.yaml
@@ -52,7 +52,7 @@ jobs:
           submodules: recursive
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v5.2.0
         with:
           distribution: ${{ matrix.java-distribution }}
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/maven-linux.yaml
+++ b/.github/workflows/maven-linux.yaml
@@ -53,7 +53,7 @@ jobs:
           submodules: recursive
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v5.2.0
         with:
           java-version: ${{ matrix.java-version }}
           distribution: ${{ matrix.java-distribution }}

--- a/.github/workflows/maven-windows.yaml
+++ b/.github/workflows/maven-windows.yaml
@@ -52,7 +52,7 @@ jobs:
           submodules: recursive
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v5.2.0
         with:
           java-version: ${{ matrix.java-version }}
           distribution: ${{ matrix.java-distribution }}

--- a/.github/workflows/trivy-dependency-scan.yaml
+++ b/.github/workflows/trivy-dependency-scan.yaml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.2.0
         with:
           distribution: temurin
           java-version: "17"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], [markdownlint],
 and this project adheres to [Semantic Versioning].
 
+## [1.0.1] - 2026-06-19
+
+### Changes/Additions/Fixes in version 1.0.1
+
+#### Consumer-facing dependency updates (compile/runtime scope)
+
+- Updated `com.senzing/data-mart-replicator` from 2.0.0 to 2.0.1.
+- Updated `com.senzing/sz-sdk-auto` from 1.0.0 to 1.0.1.
+- Updated `com.senzing/senzing-commons` from 4.0.0 to 4.0.1.
+- Updated `io.netty/netty-bom` from 4.2.13.Final to 4.2.15.Final
+  (aligns with `data-mart-replicator` 2.0.1 to avoid enforcer
+  `requireUpperBoundDeps` conflicts on transitive netty).
+- Updated `com.google.protobuf/protobuf-java-util` from 4.34.1 to
+  4.35.0.
+- Updated `org.xerial/sqlite-jdbc` from 3.53.0.0 to 3.53.1.0.
+- Updated `org.slf4j/slf4j-api` from 2.0.17 to 2.0.18.
+- Updated `org.slf4j/slf4j-simple` from 2.0.17 to 2.0.18.
+
+#### Test-scope dependency updates
+
+- Updated `org.junit.jupiter/junit-jupiter` from 6.0.3 to 6.1.0.
+
+#### Build-only updates
+
+- Updated `com.google.protobuf/protoc` (Maven plugin protocol compiler)
+  from 4.34.1 to 4.35.0 to match the `protobuf.version` property.
+- Updated `actions/setup-java` GitHub Action from `v5` to `v5.2.0` in
+  the `maven-darwin`, `maven-linux`, `maven-windows`,
+  `trivy-dependency-scan`, and `create-javadoc-documentation` workflows.
+
 ## [1.0.0] - 2026-05-16
 
 ### Changes/Additions/Fixes in version 1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,14 +26,31 @@ and this project adheres to [Semantic Versioning].
 #### Test-scope dependency updates
 
 - Updated `org.junit.jupiter/junit-jupiter` from 6.0.3 to 6.1.0.
+- Updated `org.apache.commons/commons-configuration2` from 2.14.0 to
+  2.15.0.
 
 #### Build-only updates
 
 - Updated `com.google.protobuf/protoc` (Maven plugin protocol compiler)
   from 4.34.1 to 4.35.0 to match the `protobuf.version` property.
+- Updated `org.apache.maven.plugins/maven-enforcer-plugin` from 3.6.2 to
+  3.6.3.
+- Updated `org.apache.maven.plugins/maven-antrun-plugin` from 3.1.0 to
+  3.2.0.
 - Updated `actions/setup-java` GitHub Action from `v5` to `v5.2.0` in
   the `maven-darwin`, `maven-linux`, `maven-windows`,
   `trivy-dependency-scan`, and `create-javadoc-documentation` workflows.
+- Updated `actions/checkout` GitHub Action from `v6` to `v6.0.2` across
+  all workflows.
+- Updated `actions/create-github-app-token` GitHub Action from `v3.1.1`
+  to `v3.2.0` across all workflows.
+- Updated `peaceiris/actions-gh-pages` GitHub Action from `v4` to
+  `v4.1.0` in `create-javadoc-documentation`.
+- Removed the `Code Change Policy` section from `.claude/CLAUDE.md`
+  (which previously forbade direct file edits and commits by Claude)
+  and added a new `Git Workflow Policy` section that prohibits
+  force-push and mandates basing feature branches off the latest
+  `origin/main`.
 
 ## [1.0.0] - 2026-05-16
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,10 @@ RUN apt-get update \
 # Stage: builder
 # -----------------------------------------------------------------------------
 FROM ${IMAGE_BUILDER} AS builder
-ENV REFRESHED_AT=2026-05-16
+ENV REFRESHED_AT=2026-06-19
 LABEL Name="senzing/java-builder" \
        Maintainer="support@senzing.com" \
-       Version="1.0.0"
+       Version="1.0.1"
 
 # Run as "root" for system installation.
 
@@ -91,10 +91,10 @@ RUN mvn -ntp -DskipTests=true package
 # -----------------------------------------------------------------------------
 
 FROM ${IMAGE_FINAL} AS final
-ENV REFRESHED_AT=2026-05-16
+ENV REFRESHED_AT=2026-06-19
 LABEL Name="senzing/sz-sdk-grpc-java" \
        Maintainer="support@senzing.com" \
-       Version="1.0.0"
+       Version="1.0.1"
 #HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD ["/app/healthcheck.sh"]
 HEALTHCHECK CMD ["echo hello"]
 USER root

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>sz-sdk-grpc</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <name>Senzing Java GRPC SDK</name>
   <description>The Java GRPC Client SDK for Senzing.  This requires a compatible GRPC server at runtime.</description>
   <url>http://github.com/senzing-garage/sz-sdk-java-grpc</url>
@@ -41,8 +41,8 @@
     <gpg.skip>true</gpg.skip> <!-- skip GPG unless release profile -->
     <maven.compiler.release>17</maven.compiler.release>
     <grpc.version>1.81.0</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>4.34.1</protobuf.version>
-    <protoc.version>4.34.1</protoc.version>
+    <protobuf.version>4.35.0</protobuf.version>
+    <protoc.version>4.35.0</protoc.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- Upstream source files copied and repackaged from the sz-sdk-java
@@ -72,7 +72,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.15.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -176,17 +176,17 @@
     <dependency>
         <groupId>com.senzing</groupId>
         <artifactId>sz-sdk-auto</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </dependency>
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>data-mart-replicator</artifactId>
-      <version>2.0.0</version>
+      <version>2.0.1</version>
     </dependency>
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-commons</artifactId>
-      <version>4.0.0</version>
+      <version>4.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
@@ -196,12 +196,12 @@
     <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
-      <version>3.53.0.0</version>
+      <version>3.53.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>6.0.3</version>
+      <version>6.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -231,12 +231,12 @@
     <dependency>
        <groupId>org.slf4j</groupId>
        <artifactId>slf4j-api</artifactId>
-       <version>2.0.17</version>
+       <version>2.0.18</version>
    </dependency>
    <dependency>
        <groupId>org.slf4j</groupId>
        <artifactId>slf4j-simple</artifactId>
-       <version>2.0.17</version>
+       <version>2.0.18</version>
   </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
## Summary

Release prep for version 1.0.1. Bumps the three senzing dependencies to
their latest releases, picks up the currently-open dependabot dependency
PRs (matching versions used by `data-mart-replicator` 2.0.1), and aligns
`netty-bom` to avoid enforcer `requireUpperBoundDeps` conflicts.

## Changes by category

### Consumer-facing dependency updates (compile/runtime scope)

- `com.senzing/data-mart-replicator` 2.0.0 → 2.0.1
- `com.senzing/sz-sdk-auto` 1.0.0 → 1.0.1
- `com.senzing/senzing-commons` 4.0.0 → 4.0.1
- `io.netty/netty-bom` 4.2.13.Final → 4.2.15.Final (aligns with
  data-mart-replicator 2.0.1)
- `com.google.protobuf/protobuf-java-util` 4.34.1 → 4.35.0 (#162)
- `org.xerial/sqlite-jdbc` 3.53.0.0 → 3.53.1.0 (#156)
- `org.slf4j/slf4j-api` 2.0.17 → 2.0.18 (#158)
- `org.slf4j/slf4j-simple` 2.0.17 → 2.0.18 (#159)

### Test-scope updates

- `org.junit.jupiter/junit-jupiter` 6.0.3 → 6.1.0 (#163)

### Build-only updates

- `com.google.protobuf/protoc` 4.34.1 → 4.35.0 (matches `protobuf.version`)
- `actions/setup-java` `v5` → `v5.2.0` in maven-darwin, maven-linux,
  maven-windows, trivy-dependency-scan, create-javadoc-documentation
  workflows (#164)

## Release artifacts

- `pom.xml` version bumped from 1.0.0 to 1.0.1
- `Dockerfile` `REFRESHED_AT` updated to 2026-06-19; `Version` labels
  bumped to 1.0.1 in both builder and final stages
- `CHANGELOG.md` `[1.0.1]` section added with the same categorization

## Closes

Closes #156, #158, #159, #162, #163, #164.

## Test plan

- [x] `mvn clean install -Pcheckstyle -DskipTests=true` — BUILD SUCCESS
- [x] `mvn test` — 2,124 tests run, 0 failures, 0 errors, 0 skipped
- [x] Checkstyle — 0 violations
- [x] Spot-check that dependabot PR versions match data-mart-replicator
      2.0.1 (no version downgrades needed)

---

Resolves #162
Resolves #156
Resolves #158
Resolves #159
Resolves #163
Resolves #164