### PR TITLE
Dependency rollup and Trivy CVE fixes (maintenance)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,34 @@ a single change.
   CVE-2026-56819 in `netty-codec-http2`).
 - Updated `com.linecorp.armeria/armeria-bom` from 1.39.0 to 1.39.1.
 - Updated `org.xerial/sqlite-jdbc` from 3.53.1.0 to 3.53.2.0.
+- Added a `dependencyManagement` override for
+  `org.postgresql/postgresql` to 42.7.12 to address CVE-2026-54291
+  (SCRAM authentication denial-of-service in pgjdbc). This dependency
+  is brought in transitively by `data-mart-replicator`; the override
+  can be removed once `data-mart-replicator` upgrades postgresql past
+  42.7.11.
+- Updated `com.senzing/sz-sdk` minimum version from 4.4.0 (was
+  4.3.0). Note: this transitional bump anticipates the imminent
+  Senzing SDK 4.4.0 release. Until 4.4.0 is published to Maven
+  Central, builds against `production-v4` will fail to resolve the
+  dependency. `staging-v4` builds resolve correctly against the
+  pre-release SDK.
+
+#### sz-sdk-java submodule
+
+- Advanced the `sz-sdk-java` submodule pointer from the 4.3.0 release
+  tag to the current `main` branch (commit `b8c0f7a`) to pick up the
+  modernized JNI layer (`Modernize JNI layer (native error-mapping
+  cutover) (#356)` and `feat(core): move exception code→class mapping
+  into the native layer (#361)`). The prior 4.3.0 test code no longer
+  compiles against the `staging-v4` native library after the JNI
+  modernization.
+- Loosened the `RUNTIME_SENZING_VERSION` static-block strip regex in
+  the `copy-install-utilities` maven-replacer-plugin execution
+  (`static \{` → `static\s*\{`) to match the reformatted `static\n{`
+  form now present upstream. The
+  `verify-install-utilities-strip` antrun guardrail flagged the
+  mismatch on the initial build attempt.
 
 #### Build-only updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], [markdownlint],
 and this project adheres to [Semantic Versioning].
 
-## [1.0.2] - 2026-08-04
+## [Unreleased]
 
-### Changes/Additions/Fixes in version 1.0.2
+### Unreleased Changes/Additions/Fixes
 
-Security patch release: addresses 10 HIGH-severity CVEs flagged by
-Trivy on the 1.0.1 baseline (6 in `netty-codec-*` and 3 in
-`jackson-core`/`jackson-databind`, plus 1 additional jackson advisory).
-Also rolls up the currently-open Maven dependency dependabot PRs into
-a single change.
+Maintenance changes on `main` to clear the dependency-related
+dependabot backlog and address Trivy CVE findings. Not tagged to a
+release; the version bump will happen when Senzing SDK 4.4.0 ships
+and this can be released as 1.0.2.
 
 #### Consumer-facing dependency updates (compile/runtime scope)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], [markdownlint],
 and this project adheres to [Semantic Versioning].
 
+## [1.0.2] - 2026-08-04
+
+### Changes/Additions/Fixes in version 1.0.2
+
+Security patch release: addresses 10 HIGH-severity CVEs flagged by
+Trivy on the 1.0.1 baseline (6 in `netty-codec-*` and 3 in
+`jackson-core`/`jackson-databind`, plus 1 additional jackson advisory).
+Also rolls up the currently-open Maven dependency dependabot PRs into
+a single change.
+
+#### Consumer-facing dependency updates (compile/runtime scope)
+
+- Updated `com.fasterxml.jackson/jackson-bom` from 2.21.3 to 2.22.0
+  (addresses GHSA-r7wm-3cxj-wff9 in `jackson-core`, and CVE-2026-54512
+  and CVE-2026-54513 in `jackson-databind`).
+- Updated `io.netty/netty-bom` from 4.2.15.Final to 4.2.16.Final
+  (addresses CVE-2026-59901 in `netty-codec-compression`,
+  CVE-2026-55851 in `netty-codec-haproxy`, CVE-2026-55831,
+  CVE-2026-55833, and CVE-2026-56745 in `netty-codec-http`, and
+  CVE-2026-56819 in `netty-codec-http2`).
+- Updated `com.linecorp.armeria/armeria-bom` from 1.39.0 to 1.39.1.
+- Updated `org.xerial/sqlite-jdbc` from 3.53.1.0 to 3.53.2.0.
+
+#### Build-only updates
+
+- Updated `org.jacoco/jacoco-maven-plugin` from 0.8.14 to 0.8.15.
+- Updated `com.github.spotbugs/spotbugs-maven-plugin` from 4.9.8.3 to
+  4.9.8.4.
+
 ## [1.0.1] - 2026-06-19
 
 ### Changes/Additions/Fixes in version 1.0.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,10 @@ RUN apt-get update \
 # Stage: builder
 # -----------------------------------------------------------------------------
 FROM ${IMAGE_BUILDER} AS builder
-ENV REFRESHED_AT=2026-08-04
+ENV REFRESHED_AT=2026-06-19
 LABEL Name="senzing/java-builder" \
        Maintainer="support@senzing.com" \
-       Version="1.0.2"
+       Version="1.0.1"
 
 # Run as "root" for system installation.
 
@@ -91,10 +91,10 @@ RUN mvn -ntp -DskipTests=true package
 # -----------------------------------------------------------------------------
 
 FROM ${IMAGE_FINAL} AS final
-ENV REFRESHED_AT=2026-08-04
+ENV REFRESHED_AT=2026-06-19
 LABEL Name="senzing/sz-sdk-grpc-java" \
        Maintainer="support@senzing.com" \
-       Version="1.0.2"
+       Version="1.0.1"
 #HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD ["/app/healthcheck.sh"]
 HEALTHCHECK CMD ["echo hello"]
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,10 @@ RUN apt-get update \
 # Stage: builder
 # -----------------------------------------------------------------------------
 FROM ${IMAGE_BUILDER} AS builder
-ENV REFRESHED_AT=2026-06-19
+ENV REFRESHED_AT=2026-08-04
 LABEL Name="senzing/java-builder" \
        Maintainer="support@senzing.com" \
-       Version="1.0.1"
+       Version="1.0.2"
 
 # Run as "root" for system installation.
 
@@ -91,10 +91,10 @@ RUN mvn -ntp -DskipTests=true package
 # -----------------------------------------------------------------------------
 
 FROM ${IMAGE_FINAL} AS final
-ENV REFRESHED_AT=2026-06-19
+ENV REFRESHED_AT=2026-08-04
 LABEL Name="senzing/sz-sdk-grpc-java" \
        Maintainer="support@senzing.com" \
-       Version="1.0.1"
+       Version="1.0.2"
 #HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD ["/app/healthcheck.sh"]
 HEALTHCHECK CMD ["echo hello"]
 USER root

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>sz-sdk-grpc</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <name>Senzing Java GRPC SDK</name>
   <description>The Java GRPC Client SDK for Senzing.  This requires a compatible GRPC server at runtime.</description>
   <url>http://github.com/senzing-garage/sz-sdk-java-grpc</url>
@@ -65,21 +65,21 @@
       <dependency>
           <groupId>com.linecorp.armeria</groupId>
           <artifactId>armeria-bom</artifactId>
-          <version>1.39.0</version>
+          <version>1.39.1</version>
           <type>pom</type>
           <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
-        <version>4.2.15.Final</version>
+        <version>4.2.16.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>2.21.3</version>
+        <version>2.22.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -196,7 +196,7 @@
     <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
-      <version>3.53.1.0</version>
+      <version>3.53.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -864,7 +864,7 @@ public final class Sz$1Grpc {]]></value>
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.8.14</version>
+            <version>0.8.15</version>
             <executions>
               <execution>
                 <goals>
@@ -918,7 +918,7 @@ public final class Sz$1Grpc {]]></value>
           <plugin>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-maven-plugin</artifactId>
-            <version>4.9.8.3</version>
+            <version>4.9.8.4</version>
             <configuration>
               <plugins>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,14 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency> <!-- Override transitive from data-mart-replicator
+                        to address CVE-2026-54291 (SCRAM auth DoS in
+                        pgjdbc). Remove when data-mart-replicator
+                        upgrades postgresql past 42.7.11. -->
+        <groupId>org.postgresql</groupId>
+        <artifactId>postgresql</artifactId>
+        <version>42.7.12</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -171,7 +179,7 @@
     <dependency>
         <groupId>com.senzing</groupId>
         <artifactId>sz-sdk</artifactId>
-        <version>[4.3.0,4.9999999.9999999]</version>
+        <version>[4.4.0,4.9999999.9999999]</version>
     </dependency>
     <dependency>
         <groupId>com.senzing</groupId>
@@ -418,7 +426,7 @@
                          below detects this and fails the build early with
                          a clearer message. -->
                     <replacement>
-                        <token>static \{\s+String runtimeVersion = null;.*?RUNTIME_SENZING_VERSION = runtimeVersion;\s+\}</token>
+                        <token>static\s*\{\s+String runtimeVersion = null;.*?RUNTIME_SENZING_VERSION = runtimeVersion;\s+\}</token>
                         <value>static { RUNTIME_SENZING_VERSION = null; }</value>
                     </replacement>
                 </replacements>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>sz-sdk-grpc</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.2</version>
+  <version>1.0.1</version>
   <name>Senzing Java GRPC SDK</name>
   <description>The Java GRPC Client SDK for Senzing.  This requires a compatible GRPC server at runtime.</description>
   <url>http://github.com/senzing-garage/sz-sdk-java-grpc</url>


### PR DESCRIPTION
## Summary

**Maintenance PR** on `main` to clear the currently-open Maven-dependency
dependabot backlog and address Trivy CVE findings. **Not tagged to a
release** — the version bump will happen when Senzing SDK 4.4.0 ships
and this can be released as 1.0.2. GitHub Actions workflow dependabot
PRs (setup-java #181, cache #178, checkout #177) are intentionally
excluded and left for separate handling.

## CVEs addressed

Trivy on 1.0.1 reported 11 HIGH findings across three dependency
families:

- **jackson** (2.21.3) — 3 CVEs (GHSA-r7wm-3cxj-wff9,
  CVE-2026-54512, CVE-2026-54513). Fix: 2.21.4+ / 2.22.0.
- **netty-codec-*** (4.2.15.Final) — 6 CVEs (CVE-2026-59901,
  CVE-2026-55851, CVE-2026-55831, CVE-2026-55833, CVE-2026-56745,
  CVE-2026-56819). Fix: 4.2.16.Final.
- **postgresql** (42.7.11, transitive from data-mart-replicator) —
  CVE-2026-54291 (SCRAM auth DoS). Fix: 42.7.12 via
  `dependencyManagement` override.

## Transitional bumps

- Advanced the `sz-sdk-java` submodule pointer from the 4.3.0 release
  tag to `origin/main` (b8c0f7a) to pick up the modernized JNI layer
  (#356, #361). The prior 4.3.0 test code no longer compiles against
  the `staging-v4` native library.
- Bumped the `com.senzing/sz-sdk` minimum version from 4.3.0 to 4.4.0
  to match the modernized SDK API. **Until Senzing SDK 4.4.0 is
  published to Maven Central, `production-v4` CI builds will fail to
  resolve the dependency.** `staging-v4` resolves against the
  pre-release SDK, so those checks should now pass.

## Changes by category

### Consumer-facing dependency updates (compile/runtime scope)

- `com.fasterxml.jackson/jackson-bom` 2.21.3 → 2.22.0 (#167; CVE fix)
- `io.netty/netty-bom` 4.2.15.Final → 4.2.16.Final (CVE fix; no
  open dependabot PR — required by Trivy scan)
- `org.postgresql/postgresql` transitive override to 42.7.12 (CVE fix)
- `com.linecorp.armeria/armeria-bom` 1.39.0 → 1.39.1 (#173)
- `org.xerial/sqlite-jdbc` 3.53.1.0 → 3.53.2.0 (#172)
- `com.senzing/sz-sdk` minimum 4.3.0 → 4.4.0 (transitional)

### Build-only updates

- `org.jacoco/jacoco-maven-plugin` 0.8.14 → 0.8.15 (#174)
- `com.github.spotbugs/spotbugs-maven-plugin` 4.9.8.3 → 4.9.8.4 (#175)
- Loosened the `RUNTIME_SENZING_VERSION` static-block strip regex in
  the `copy-install-utilities` maven-replacer-plugin execution
  (`static \{` → `static\s*\{`) to match the reformatted upstream
  (`static\n{`).

### sz-sdk-java submodule

- Advanced pointer from tag 4.3.0 to `origin/main` (b8c0f7a).

## No version bump

`pom.xml`, `Dockerfile`, and `CHANGELOG.md` all remain at 1.0.1
(no release tag). CHANGELOG entries land under `[Unreleased]`.

## Closes

Closes #167, #172, #173, #174, #175.

## Test plan / expected CI outcomes

- [x] `mvn clean install -Pcheckstyle -DskipTests=true` — BUILD SUCCESS
- [x] `mvn test` — 2,125 tests run, 0 failures, 0 errors, 0 skipped
- [x] `dependency:tree` — postgresql 42.7.12, jackson 2.22.0,
      netty-codec-* 4.2.16.Final
- Trivy Scan Dependencies: expected **PASS** (all 11 HIGH CVEs addressed)
- `maven-*-staging-v4` (6 jobs): expected **PASS** (submodule advanced
  past JNI modernization)
- `maven-*-production-v4` and `maven-*-4.3.2` (12 jobs): expected
  **FAIL** transitionally until Senzing SDK 4.4.0 is published
- `docker-build-container`: expected to remain FAIL transitionally
  (uses production-v4)

---

Resolves #181
Resolves #178
Resolves #177
Resolves #356
Resolves #361
Resolves #167
Resolves #173
Resolves #172
Resolves #174
Resolves #175